### PR TITLE
Dasherize attributes keys

### DIFF
--- a/lib/JSONAPISerializer.js
+++ b/lib/JSONAPISerializer.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash');
 const joi = require('joi');
+const dasherize = require('dasherize');
 
 module.exports = class JSONAPISerializer {
   constructor(opts) {
@@ -110,6 +111,8 @@ module.exports = class JSONAPISerializer {
     if (options.whitelist.length > 0) {
       data = _.pick(data, options.whitelist);
     }
+
+    data = dasherize(data);
 
     return _.pick(data, _.difference(Object.keys(data), _.concat([options.id], Object.keys(options.relationships), options.blacklist)));
   }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "mocha": "^2.4.5"
   },
   "dependencies": {
+    "dasherize": "^2.0.0",
     "joi": "^8.0.3",
     "lodash": "^4.5.1"
   }

--- a/test/integration/examples.js
+++ b/test/integration/examples.js
@@ -114,8 +114,8 @@ describe('Examples', function() {
       'id': '1'
     });
     expect(includedAuhor1).to.have.property('attributes');
-    expect(includedAuhor1.attributes).to.have.property('firstName');
-    expect(includedAuhor1.attributes).to.have.property('lastName');
+    expect(includedAuhor1.attributes).to.have.property('first-name');
+    expect(includedAuhor1.attributes).to.have.property('last-name');
     expect(includedAuhor1.attributes).to.have.property('email');
     expect(includedAuhor1.attributes).to.have.property('age');
     expect(includedAuhor1.attributes).to.have.property('gender');


### PR DESCRIPTION
Dasherize attributes keys to follow JSON API recommendation. As discussed in https://github.com/danivek/json-api-serializer/issues/3

JSON recommends to use dashes for multiple work variables http://jsonapi.org/recommendations/#naming
This commit forces all attributes's keys to follow this recommendation.