### PR TITLE
Data should be tested to be objects and not necessarily plain objects

### DIFF
--- a/lib/JSONAPISerializer.js
+++ b/lib/JSONAPISerializer.js
@@ -158,7 +158,7 @@ module.exports = class JSONAPISerializer {
     };
 
     // support for unpopulated relationships (an id, or array of ids)
-    if (!_.isPlainObject(rData)) {
+    if (!_.isObjectLike(rData)) {
       // Relationship has not been populated
       serializedRelationship.id = rData.toString();
     } else {
@@ -189,9 +189,9 @@ module.exports = class JSONAPISerializer {
 
   _convertCase(data, convertCaseOptions) {
     let converted;
-    if (_.isArray(data) || _.isPlainObject(data)) {
+    if (_.isArray(data) || _.isObjectLike(data)) {
       converted = _.transform(data, (result, value, key) => {
-        if (_.isArray(value) || _.isPlainObject(value)) {
+        if (_.isArray(value) || _.isObjectLike(value)) {
           result[this._convertCase(key, convertCaseOptions)] = this._convertCase(value, convertCaseOptions);
         } else {
           result[this._convertCase(key, convertCaseOptions)] = value;


### PR DESCRIPTION
Given loadash's definition, a plain object is an object with a prototype of null.
*json-api-serializer* tests input type either to detect if it can address attributes using index or if it needs to go further in the recursion.
Input objects does not need to be plain objects as the prototype would not matter anyway.

Moreover, in my use case, I get my data from an ORM which provides prototype function to manipulate data. When I serialize the data coming out of the ORM, I expect *json-api-serializer* to just take care of the data and ignore prototype functions.

Note that this PR does not update `isPlainObject` in [JSONAPISerializer.js:52](https://github.com/dynamiccast/json-api-serializer/blob/f62d96f9ab481a026a812489d1b046281600eb7d/lib/JSONAPISerializer.js#L52) as is it safe to assume if user provides `extraOptions` it will be a plain object.