### PR TITLE
Add async serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # json-api-serializer
 [![Build Status](https://travis-ci.org/danivek/json-api-serializer.svg?branch=master)](https://travis-ci.org/danivek/json-api-serializer)
 [![Coverage Status](https://coveralls.io/repos/github/danivek/json-api-serializer/badge.svg?branch=master)](https://coveralls.io/github/danivek/json-api-serializer?branch=master)
-[![npm](https://img.shields.io/npm/v/json-api-serializer.svg?maxAge=2592000)](https://www.npmjs.org/package/json-api-serializer)
+[![npm](https://img.shields.io/npm/v/json-api-serializer.svg)](https://www.npmjs.org/package/json-api-serializer)
 
 A Node.js framework agnostic library for serializing your data to [JSON API](http://jsonapi.org/) compliant responses (a specification for building APIs in JSON).
 
@@ -38,11 +38,13 @@ Serializer.register(type, options);
         - **alternativeKey** (optional): An alternative key to use if relationship key not exist (example: 'author_id' as an alternative key for 'author' relationship). See [issue #12](https://github.com/danivek/json-api-serializer/issues/12).
         - **schema** (optional): A custom schema for serializing the relationship. If no schema define, it use the default one.
         - **links** (optional): An *object* or a *function* that describes the links for the relationship. (If it is an object values can be string or function).
-- **convertCase** (optional): Case conversion for outputted data. Value can be : `kebab-case`, `snake_case`, `camelCase`
+- **convertCase** (optional): Case conversion for serializing data. Value can be : `kebab-case`, `snake_case`, `camelCase`
+- **unconvertCase** (optional): Case conversion for deserializing data. Value can be : `kebab-case`, `snake_case`, `camelCase`
+
 
 ## Usage
 
-input data (can be a simple object or an array of objects)
+input data (can be an object or an array of objects)
 ```javascript
 // Data
 var data = {
@@ -77,6 +79,7 @@ var data = {
 }
 ```
 
+### Register
 Register your resources types :
 ```javascript
 var JSONAPISerializer = require('json-api-serializer');
@@ -148,6 +151,8 @@ Serializer.register('comment', 'only-body', {
   id: '_id',
 });
 ```
+
+### Serialize
 
 Serialize it with the corresponding resource type, data and optional extra options :
 
@@ -260,6 +265,56 @@ The output data will be :
 ```
 Some others examples are available in [ tests folders](https://github.com/danivek/json-api-serializer/blob/master/test/)
 
+### Deserialize
+
+```javascript
+var data = {
+  data: {
+    type: 'article',
+    id: '1',
+    attributes: {
+      title: 'JSON API paints my bikeshed!',
+      body: 'The shortest article. Ever.',
+      created: '2015-05-22T14:56:29.000Z'
+    },
+    relationships: {
+      author: {
+        data: {
+          type: 'people',
+          id: '1'
+        }
+      },
+      comments: {
+        data: [{
+          type: 'comment',
+          id: '1'
+        }, {
+          type: 'comment',
+          id: '2'
+        }]
+      }
+    }
+  }
+};
+
+Serializer.deserialize('article', data);
+```
+
+```JSON
+{
+  "id": "1",
+  "title": "JSON API paints my bikeshed!",
+  "body": "The shortest article. Ever.",
+  "created": "2015-05-22T14:56:29.000Z",
+  "author": "1",
+  "comments": [
+    "1",
+    "2"
+  ]
+}
+```
+
+
 ## Custom schemas
 
 It is possible to define multiple custom schemas for a resource type :
@@ -268,10 +323,11 @@ It is possible to define multiple custom schemas for a resource type :
 Serializer.register(type, 'customSchema', options);
 ```
 
-If you want to apply this schema on the primary data :
+Then you can apply this schema on the primary data when serialize or deserialize :
 
 ```javascript
 Serializer.serialize('article', data, 'customSchema', {count: 2});
+Serializer.deserialize('article', jsonapiData, 'customSchema');
 ```
 
 Or if you want to apply this schema on a relationship data, define this schema on relationships options with the key `schema` :

--- a/README.md
+++ b/README.md
@@ -162,7 +162,14 @@ Serializer.register('comment', 'only-body', {
 Serialize it with the corresponding resource type, data and optional extra options :
 
 ```javascript
-Serializer.serialize('article', data, {count: 2});
+// Synchronously (blocking)
+const result = Serializer.serialize('article', data, {count: 2});
+
+// Asynchronously (non-blocking)
+Serializer.serializeAsync('article', data, {count: 2})
+  .then((result) => {
+    ...
+  });
 ```
 
 The output data will be :
@@ -334,6 +341,7 @@ Then you can apply this schema on the primary data when serialize or deserialize
 
 ```javascript
 Serializer.serialize('article', data, 'customSchema', {count: 2});
+Serializer.serializeAsync('article', data, 'customSchema', {count: 2});
 Serializer.deserialize('article', jsonapiData, 'customSchema');
 ```
 

--- a/lib/JSONAPISerializer.js
+++ b/lib/JSONAPISerializer.js
@@ -44,6 +44,7 @@ module.exports = class JSONAPISerializer {
       topLevelLinks: joi.alternatives([joi.func(), joi.object()]).default({}),
       topLevelMeta: joi.alternatives([joi.func(), joi.object()]).default({}),
       convertCase: joi.string().valid('kebab-case', 'snake_case', 'camelCase'),
+      unconvertCase: joi.string().valid('kebab-case', 'snake_case', 'camelCase'),
     }).required();
 
     const validated = joi.validate(options, optionsSchema);
@@ -119,6 +120,60 @@ module.exports = class JSONAPISerializer {
       data: this.serializeData(type, data, resourceOpts, included),
       included: this.serializeIncluded(included),
     };
+  }
+
+  /**
+   * Deserialize JSON API document data.
+   * Input data can be a simple object or an array of objects.
+   *
+   * @method JSONAPISerializer#deserialize
+   * @param {string} type resource's type.
+   * @param {Object} data JSON API input data.
+   * @param {string} [schema=default] resource's schema name.
+   * @return {Object} deserialized data.
+   */
+  deserialize(type, data, schema) {
+    schema = schema || 'default';
+
+    if (!this.schemas[type]) {
+      throw new Error('No type registered for ' + type);
+    }
+
+    if (schema && !this.schemas[type][schema]) {
+      throw new Error('No schema ' + schema + ' registered for ' + type);
+    }
+
+    const resourceOpts = this.schemas[type][schema];
+    let deserializedData = {};
+
+    if (data.data) {
+      // Deserialize id
+      deserializedData[resourceOpts.id] = data.data.id || undefined;
+
+      // Deserialize attributes
+      Object.assign(deserializedData, data.data.attributes);
+
+      // Deserialize relationships
+      _.forOwn(data.data.relationships, (value, relationship) => {
+        // Support alternativeKey options for relationships
+        let relationshipKey = relationship;
+        if (resourceOpts.relationships[relationshipKey] && resourceOpts.relationships[relationshipKey].alternativeKey) {
+          relationshipKey = resourceOpts.relationships[relationshipKey].alternativeKey;
+        }
+
+        if (_.isArray(value.data)) {
+          deserializedData[relationshipKey] = value.data.map((d) => d.id);
+        } else {
+          deserializedData[relationshipKey] = value.data.id;
+        }
+      });
+
+      if (resourceOpts.unconvertCase) {
+        deserializedData = this._convertCase(deserializedData, resourceOpts.unconvertCase);
+      }
+    }
+
+    return deserializedData;
   }
 
   /**

--- a/lib/JSONAPISerializer.js
+++ b/lib/JSONAPISerializer.js
@@ -130,7 +130,7 @@ module.exports = class JSONAPISerializer {
   }
 
   /**
-   * Serialze input data to a JSON API compliant response.
+   * Asynchronously serialze input data to a JSON API compliant response.
    * Input data can be a simple object or an array of objects.
    *
    * @see {@link http://jsonapi.org/format/#document-top-level}

--- a/lib/JSONAPISerializer.js
+++ b/lib/JSONAPISerializer.js
@@ -164,31 +164,34 @@ module.exports = class JSONAPISerializer {
     const resourceOpts = this.schemas[type][schema];
     const included = [];
 
-    if (!Array.isArray(data)) {
-      return Promise.resolve({
-        jsonapi: {
-          version: '1.0',
-        },
-        meta: this.processOptionsValues(extraOptions, resourceOpts.topLevelMeta),
-        links: this.processOptionsValues(extraOptions, resourceOpts.topLevelLinks),
-        data: this.serializeData(type, data, resourceOpts, included),
-        included: this.serializeIncluded(included),
-      });
-    }
-
     return new Promise((resolve, reject) => {
       let serializedData;
       let serializedIncludes;
+      const isDataArray = Array.isArray(data);
 
-      // convert data into stream with serialization-transform
-      const dataStream = intoStream.obj(data)
+      // Convert data into stream with serialization-transform. Single objects
+      // will be converted to an array to unify the serialization process. They
+      // will be converted back to a single object at the end.
+      const dataStream = intoStream.obj(isDataArray ? data : [data])
         .pipe(through.obj((item, enc, callback) => {
-          callback(null, this.serializeData(type, item, resourceOpts, included));
+          // Serialize a single item of the data-array.
+          const serializedItem = this.serializeData(type, item, resourceOpts, included);
+
+          // If the serialized item is null, we won't push it to the stream,
+          // as pushing a null-value causes streams to end.
+          if (serializedItem === null) {
+            return callback();
+          }
+
+          return callback(null, serializedItem);
         }));
 
+      // Concat the processed stream back to an array.
       streamToArray(dataStream)
         .then((result) => {
           serializedData = result;
+          // After the serialization of the dataStream is finished, the included
+          // objects (side-loaded relations) need to be serialized as well.
           return this.serializeIncludedAsync(included);
         })
         .then((result) => {
@@ -199,7 +202,9 @@ module.exports = class JSONAPISerializer {
             },
             meta: this.processOptionsValues(extraOptions, resourceOpts.topLevelMeta),
             links: this.processOptionsValues(extraOptions, resourceOpts.topLevelLinks),
-            data: serializedData,
+            // If the source data was an array, we just pass the serialized data array.
+            // Otherwise we try to take the first (and only) item of it or pass null.
+            data: isDataArray ? serializedData : (serializedData[0] || null),
             included: serializedIncludes,
           });
         })

--- a/lib/JSONAPISerializer.js
+++ b/lib/JSONAPISerializer.js
@@ -3,6 +3,7 @@
 const _ = require('lodash');
 const joi = require('joi');
 const intoStream = require('into-stream');
+const through = require('through2');
 const dedupeStream = require('unique-stream');
 const streamToArray = require('stream-to-array');
 
@@ -133,7 +134,7 @@ module.exports = class JSONAPISerializer {
    * Input data can be a simple object or an array of objects.
    *
    * @see {@link http://jsonapi.org/format/#document-top-level}
-   * @method JSONAPISerializer#serialize
+   * @method JSONAPISerializer#serializeAsync
    * @param {string} type resource's type.
    * @param {Object|Object[]} data input data.
    * @param {string} [schema=default] resource's schema name.
@@ -163,36 +164,46 @@ module.exports = class JSONAPISerializer {
     const resourceOpts = this.schemas[type][schema];
     const included = [];
 
-    return new Promise((resolve, reject) => {
-      if (!Array.isArray(data)) {
-        return resolve({
-          jsonapi: {
-            version: '1.0',
-          },
-          meta: this.processOptionsValues(extraOptions, resourceOpts.topLevelMeta),
-          links: this.processOptionsValues(extraOptions, resourceOpts.topLevelLinks),
-          data: this.serializeData(type, data, resourceOpts, included),
-          included: this.serializeIncluded(included),
-        });
-      }
-
-      const serializedData = [];
-      const dataStream = intoStream.obj(data);
-      dataStream.on('data', (item) => {
-        serializedData.push(this.serializeData(type, item, resourceOpts, included));
-      });
-
-      dataStream.on('end', () => resolve({
+    if (!Array.isArray(data)) {
+      return Promise.resolve({
         jsonapi: {
           version: '1.0',
         },
         meta: this.processOptionsValues(extraOptions, resourceOpts.topLevelMeta),
         links: this.processOptionsValues(extraOptions, resourceOpts.topLevelLinks),
-        data: serializedData,
+        data: this.serializeData(type, data, resourceOpts, included),
         included: this.serializeIncluded(included),
-      }));
+      });
+    }
 
-      dataStream.on('error', reject);
+    return new Promise((resolve, reject) => {
+      let serializedData;
+      let serializedIncludes;
+
+      // convert data into stream with serialization-transform
+      const dataStream = intoStream.obj(data)
+        .pipe(through.obj((item, enc, callback) => {
+          callback(null, this.serializeData(type, item, resourceOpts, included));
+        }));
+
+      streamToArray(dataStream)
+        .then((result) => {
+          serializedData = result;
+          return this.serializeIncludedAsync(included);
+        })
+        .then((result) => {
+          serializedIncludes = result;
+          return resolve({
+            jsonapi: {
+              version: '1.0',
+            },
+            meta: this.processOptionsValues(extraOptions, resourceOpts.topLevelMeta),
+            links: this.processOptionsValues(extraOptions, resourceOpts.topLevelLinks),
+            data: serializedData,
+            included: serializedIncludes,
+          });
+        })
+        .catch(reject);
     });
   }
 

--- a/lib/JSONAPISerializer.js
+++ b/lib/JSONAPISerializer.js
@@ -3,6 +3,8 @@
 const _ = require('lodash');
 const joi = require('joi');
 const intoStream = require('into-stream');
+const dedupeStream = require('unique-stream');
+const streamToArray = require('stream-to-array');
 
 /**
  * JSONAPISerializer class.
@@ -328,6 +330,29 @@ module.exports = class JSONAPISerializer {
   serializeIncluded(included) {
     const serializedIncluded = _.uniqWith(included, _.isEqual);
     return Object.keys(serializedIncluded).length > 0 ? serializedIncluded : undefined;
+  }
+
+  /**
+   * Serialize top level 'included' key asynchronously: an array of resource objects that are related to the resource data.
+   * Remove all duplicated resource.
+   *
+   * @method JSONAPISerializer#serializeIncludedAsync
+   * @private
+   * @param {Object[]} included.
+   * @return {Promise} resolves with serialized included.
+   */
+  serializeIncludedAsync(included) {
+    return new Promise((resolve, reject) => {
+      if (included.length === 0) {
+        return resolve(undefined);
+      }
+
+      const uniqueStream = intoStream.obj(included)
+        .pipe(dedupeStream(item => `${item.type}-${item.id}`));
+
+      return streamToArray(uniqueStream)
+        .then(resolve, reject);
+    });
   }
 
   /**

--- a/lib/JSONAPISerializer.js
+++ b/lib/JSONAPISerializer.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash');
 const joi = require('joi');
+const intoStream = require('into-stream');
 
 /**
  * JSONAPISerializer class.
@@ -123,6 +124,74 @@ module.exports = class JSONAPISerializer {
       data: this.serializeData(type, data, resourceOpts, included),
       included: this.serializeIncluded(included),
     };
+  }
+
+  /**
+   * Serialze input data to a JSON API compliant response.
+   * Input data can be a simple object or an array of objects.
+   *
+   * @see {@link http://jsonapi.org/format/#document-top-level}
+   * @method JSONAPISerializer#serialize
+   * @param {string} type resource's type.
+   * @param {Object|Object[]} data input data.
+   * @param {string} [schema=default] resource's schema name.
+   * @param {Object} [extraOptions] additional data that can be used in topLevelMeta options.
+   * @return {Promise} resolves with serialized data.
+   */
+  serializeAsync(type, data, schema, extraOptions) {
+    // Support optional arguments (schema)
+    if (arguments.length === 3) {
+      if (_.isPlainObject(schema)) {
+        extraOptions = schema;
+        schema = 'default';
+      }
+    }
+
+    schema = schema || 'default';
+    extraOptions = extraOptions || {};
+
+    if (!this.schemas[type]) {
+      throw new Error(`No type registered for ${type}`);
+    }
+
+    if (schema && !this.schemas[type][schema]) {
+      throw new Error(`No schema ${schema} registered for ${type}`);
+    }
+
+    const resourceOpts = this.schemas[type][schema];
+    const included = [];
+
+    return new Promise((resolve, reject) => {
+      if (!Array.isArray(data)) {
+        return resolve({
+          jsonapi: {
+            version: '1.0',
+          },
+          meta: this.processOptionsValues(extraOptions, resourceOpts.topLevelMeta),
+          links: this.processOptionsValues(extraOptions, resourceOpts.topLevelLinks),
+          data: this.serializeData(type, data, resourceOpts, included),
+          included: this.serializeIncluded(included),
+        });
+      }
+
+      const serializedData = [];
+      const dataStream = intoStream.obj(data);
+      dataStream.on('data', (item) => {
+        serializedData.push(this.serializeData(type, item, resourceOpts, included));
+      });
+
+      dataStream.on('end', () => resolve({
+        jsonapi: {
+          version: '1.0',
+        },
+        meta: this.processOptionsValues(extraOptions, resourceOpts.topLevelMeta),
+        links: this.processOptionsValues(extraOptions, resourceOpts.topLevelLinks),
+        data: serializedData,
+        included: this.serializeIncluded(included),
+      }));
+
+      dataStream.on('error', reject);
+    });
   }
 
   /**

--- a/lib/JSONAPISerializer.js
+++ b/lib/JSONAPISerializer.js
@@ -349,26 +349,28 @@ module.exports = class JSONAPISerializer {
   }
 
   /**
-   * Serialize top level 'included' key asynchronously: an array of resource objects that are related to the resource data.
-   * Remove all duplicated resource.
+   * Asynchronously serialize top level 'included' key: an array of resource
+   * objects that are related to the resource data.
+   * Remove all duplicated items.
    *
    * @method JSONAPISerializer#serializeIncludedAsync
    * @private
    * @param {Object[]} included.
-   * @return {Promise} resolves with serialized included.
+   * @return {Promise} resolves with serialized included data.
    */
   serializeIncludedAsync(included) {
-    return new Promise((resolve, reject) => {
-      if (included.length === 0) {
-        return resolve(undefined);
-      }
+    if (included.length === 0) {
+      return Promise.resolve(undefined);
+    }
 
-      const uniqueStream = intoStream.obj(included)
-        .pipe(dedupeStream(item => `${item.type}-${item.id}`));
+    // Convert array into stream and remove duplicates. Duplicates
+    // are identified by the comparison of a compound key of their
+    // `type` and `id` fields.
+    const uniqueStream = intoStream.obj(included)
+      .pipe(dedupeStream(item => `${item.type}-${item.id}`));
 
-      return streamToArray(uniqueStream)
-        .then(resolve, reject);
-    });
+    // Concat the stream to an array (which resolves with a promise).
+    return streamToArray(uniqueStream);
   }
 
   /**

--- a/lib/JSONAPISerializer.js
+++ b/lib/JSONAPISerializer.js
@@ -164,52 +164,49 @@ module.exports = class JSONAPISerializer {
     const resourceOpts = this.schemas[type][schema];
     const included = [];
 
-    return new Promise((resolve, reject) => {
-      let serializedData;
-      let serializedIncludes;
-      const isDataArray = Array.isArray(data);
+    let serializedData;
+    let serializedIncludes;
+    const isDataArray = Array.isArray(data);
 
-      // Convert data into stream with serialization-transform. Single objects
-      // will be converted to an array to unify the serialization process. They
-      // will be converted back to a single object at the end.
-      const dataStream = intoStream.obj(isDataArray ? data : [data])
-        .pipe(through.obj((item, enc, callback) => {
-          // Serialize a single item of the data-array.
-          const serializedItem = this.serializeData(type, item, resourceOpts, included);
+    // Convert data into stream with serialization-transform. Single objects
+    // will be converted to an array to unify the serialization process. They
+    // will be converted back to a single object at the end.
+    const dataStream = intoStream.obj(isDataArray ? data : [data])
+      .pipe(through.obj((item, enc, callback) => {
+        // Serialize a single item of the data-array.
+        const serializedItem = this.serializeData(type, item, resourceOpts, included);
 
-          // If the serialized item is null, we won't push it to the stream,
-          // as pushing a null-value causes streams to end.
-          if (serializedItem === null) {
-            return callback();
-          }
+        // If the serialized item is null, we won't push it to the stream,
+        // as pushing a null-value causes streams to end.
+        if (serializedItem === null) {
+          return callback();
+        }
 
-          return callback(null, serializedItem);
-        }));
+        return callback(null, serializedItem);
+      }));
 
-      // Concat the processed stream back to an array.
-      streamToArray(dataStream)
-        .then((result) => {
-          serializedData = result;
-          // After the serialization of the dataStream is finished, the included
-          // objects (side-loaded relations) need to be serialized as well.
-          return this.serializeIncludedAsync(included);
-        })
-        .then((result) => {
-          serializedIncludes = result;
-          return resolve({
-            jsonapi: {
-              version: '1.0',
-            },
-            meta: this.processOptionsValues(extraOptions, resourceOpts.topLevelMeta),
-            links: this.processOptionsValues(extraOptions, resourceOpts.topLevelLinks),
-            // If the source data was an array, we just pass the serialized data array.
-            // Otherwise we try to take the first (and only) item of it or pass null.
-            data: isDataArray ? serializedData : (serializedData[0] || null),
-            included: serializedIncludes,
-          });
-        })
-        .catch(reject);
-    });
+    // Concat the processed stream back to an array and return promise-chain.
+    return streamToArray(dataStream)
+      .then((result) => {
+        serializedData = result;
+        // After the serialization of the dataStream is finished, the included
+        // objects (side-loaded relations) need to be serialized as well.
+        return this.serializeIncludedAsync(included);
+      })
+      .then((result) => {
+        serializedIncludes = result;
+        return {
+          jsonapi: {
+            version: '1.0',
+          },
+          meta: this.processOptionsValues(extraOptions, resourceOpts.topLevelMeta),
+          links: this.processOptionsValues(extraOptions, resourceOpts.topLevelLinks),
+          // If the source data was an array, we just pass the serialized data array.
+          // Otherwise we try to take the first (and only) item of it or pass null.
+          data: isDataArray ? serializedData : (serializedData[0] || null),
+          included: serializedIncludes,
+        };
+      });
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-api-serializer",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Framework agnostic JSON API serializer.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "joi": "^8.0.3",
     "lodash": "^4.5.1",
     "stream-to-array": "^2.3.0",
+    "through2": "^2.0.3",
     "unique-stream": "^2.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "mocha": "^2.4.5"
   },
   "dependencies": {
+    "into-stream": "^3.1.0",
     "joi": "^8.0.3",
     "lodash": "^4.5.1"
   }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
   "dependencies": {
     "into-stream": "^3.1.0",
     "joi": "^8.0.3",
-    "lodash": "^4.5.1"
+    "lodash": "^4.5.1",
+    "stream-to-array": "^2.3.0",
+    "unique-stream": "^2.2.1"
   }
 }

--- a/test/helpers/tick-counter.js
+++ b/test/helpers/tick-counter.js
@@ -1,0 +1,19 @@
+class TickCounter {
+  constructor(max) {
+    this.ticks = 0;
+    this.max = max;
+
+    this.countTicks();
+  }
+
+  countTicks() {
+    setImmediate(() => {
+      this.ticks += 1;
+      if (this.max > this.ticks) {
+        this.countTicks();
+      }
+    });
+  }
+}
+
+module.exports = TickCounter;

--- a/test/helpers/tick-counter.js
+++ b/test/helpers/tick-counter.js
@@ -1,3 +1,5 @@
+'use strict';
+
 class TickCounter {
   constructor(max) {
     this.ticks = 0;

--- a/test/integration/examples.js
+++ b/test/integration/examples.js
@@ -128,4 +128,15 @@ describe('Examples', function() {
     expect(includedComment1.attributes).to.not.have.property('created');
     done();
   });
+
+  it('should serialize articles data (async)', () => {
+    var expected = Serializer.serialize('article', articlesData, {
+      count: 2
+    });
+    return Serializer.serializeAsync('article', articlesData, { count: 2 })
+      .then((actual) => {
+        expect(actual).to.deep.equal(expected);
+      })
+
+  });
 });

--- a/test/unit/JSONAPISerializer.test.js
+++ b/test/unit/JSONAPISerializer.test.js
@@ -770,6 +770,14 @@ describe('JSONAPISerializer', function() {
         })
     );
 
+    it('should serialize a single object of data', () =>
+      Serializer.serializeAsync('articles', dataArray[0])
+        .then((serializedData) => {
+          expect(serializedData.data.id).to.eql('1');
+          expect(serializedData.data.attributes.title).to.eql('Article 1');
+        })
+    );
+
     it('should serialize an array of data', () =>
       Serializer.serializeAsync('articles', dataArray)
         .then((serializedData) => {

--- a/test/unit/JSONAPISerializer.test.js
+++ b/test/unit/JSONAPISerializer.test.js
@@ -653,6 +653,87 @@ describe('JSONAPISerializer', function() {
     });
   });
 
+  describe('serializeAsync', function() {
+    const Serializer = new JSONAPISerializer();
+    const dataArray = [{
+      id: 1,
+      title: 'Article 1',
+    }, {
+      id: 2,
+      title: 'Article 2',
+    }, {
+      id: 3,
+      title: 'Article 3',
+    }]
+
+    Serializer.register('articles', {
+      topLevelMeta: {
+        count: function(options) {
+          return options.count
+        }
+      }
+    });
+
+    it('should return a Promise', () => {
+      const promise = Serializer.serializeAsync('articles', {});
+      expect(promise).to.be.instanceOf(Promise);
+    });
+
+    it('should serialize empty single data', () =>
+      Serializer.serializeAsync('articles', {})
+        .then((serializedData) => {
+          expect(serializedData.data).to.eql(null);
+          expect(serializedData.included).to.be.undefined;
+        })
+    );
+
+    it('should serialize empty array data', () =>
+      Serializer.serializeAsync('articles', [])
+        .then((serializedData) => {
+          expect(serializedData.data).to.eql([]);
+          expect(serializedData.included).to.be.undefined;
+        })
+    );
+
+    it('should serialize empty array data', () =>
+      Serializer.serializeAsync('articles', [])
+        .then((serializedData) => {
+          expect(serializedData.data).to.eql([]);
+          expect(serializedData.included).to.be.undefined;
+        })
+    );
+
+    it('should serialize an array of data', () =>
+      Serializer.serializeAsync('articles', dataArray)
+        .then((serializedData) => {
+          expect(serializedData.data.length).to.eql(3);
+        })
+    );
+
+    it('should serialize each array item on next tick', () => {
+      let ticks = 0;
+      setImmediate(() => {
+        ticks++;
+        setImmediate(() => {
+          ticks++;
+          setImmediate(() => {
+            ticks++;
+            setImmediate(() => {
+              ticks++;
+              setImmediate(() => {
+                ticks++;
+              })
+            })
+          })
+        })
+      });
+      return Serializer.serializeAsync('articles', dataArray)
+        .then(() => {
+          expect(ticks).to.eql(4);
+        })
+    });
+  });
+
   describe('deserialize', function() {
     it('should deserialize data with relationships', function(done) {
       const Serializer = new JSONAPISerializer();

--- a/test/unit/JSONAPISerializer.test.js
+++ b/test/unit/JSONAPISerializer.test.js
@@ -5,23 +5,7 @@ const expect = require('chai').expect;
 const _ = require('lodash');
 const ObjectID = require('bson-objectid');
 
-class TickCounter {
-  constructor(max) {
-    this.ticks = 0;
-    this.max = max;
-
-    this.countTicks();
-  }
-
-  countTicks() {
-    setImmediate(() => {
-      this.ticks++;
-      if (this.max > this.ticks) {
-        this.countTicks();
-      }
-    })
-  }
-}
+const TickCounter = require('../helpers/tick-counter');
 
 const JSONAPISerializer = require('../../');
 

--- a/test/unit/JSONAPISerializer.test.js
+++ b/test/unit/JSONAPISerializer.test.js
@@ -778,25 +778,10 @@ describe('JSONAPISerializer', function() {
     );
 
     it('should serialize each array item on next tick', () => {
-      let ticks = 0;
-      setImmediate(() => {
-        ticks++;
-        setImmediate(() => {
-          ticks++;
-          setImmediate(() => {
-            ticks++;
-            setImmediate(() => {
-              ticks++;
-              setImmediate(() => {
-                ticks++;
-              })
-            })
-          })
-        })
-      });
+      const tickCounter = new TickCounter(5);
       return Serializer.serializeAsync('articles', dataArray)
         .then(() => {
-          expect(ticks).to.eql(4);
+          expect(tickCounter.ticks).to.eql(4);
         })
     });
   });


### PR DESCRIPTION
Proposal of an implementation of asynchronous serialization (see #18).

Notes:
- I added asynchronous and non-blocking deduplication for included objects, too.
- Before we can merge it, we need to add `serializeAsync()` to the README.
- I ported some of the unit-tests for `serialize` to `serializeAsync`. Maybe we could abstract shared functionality of `serialize` and `serializeAsync` in the future to reduce test-boilerplate. But that should be a separate issue and PR to reduce the diff and complexity of this PR).
- To assure that `serializeAsync` is not blocking the loop, I added a test-helper which counts ticks. Maybe we should put this into a separate file (or even publish it as a separate module).