### PR TITLE
[bugfix] Handle null relationships

### DIFF
--- a/lib/JSONAPISerializer.js
+++ b/lib/JSONAPISerializer.js
@@ -358,7 +358,7 @@ module.exports = class JSONAPISerializer {
           deserializedData[relationshipKey] = value.data.map(d => (included
             ? this.deserializeIncluded(d.type, d.id, resourceOpts.relationships[relationshipKey], included)
             : d.id));
-        } else {
+        } else if (value.data !== null) {
           deserializedData[relationshipKey] = included
             ? this.deserializeIncluded(value.data.type, value.data.id, resourceOpts.relationships[relationshipKey], included)
             : value.data.id;

--- a/test/unit/JSONAPISerializer.test.js
+++ b/test/unit/JSONAPISerializer.test.js
@@ -1130,6 +1130,9 @@ describe('JSONAPISerializer', function() {
                 type: 'comment',
                 id: '2'
               }]
+            },
+            posts: {
+              data: null
             }
           }
         }


### PR DESCRIPTION
Currently if a relationship is null it will be serialized without a value
which prevents the same serializer from being able to deserialize it. This
PR adds a check to make sure the value exists before attempting to
deserialize it.