### PR TITLE
[bugfix] Allow relationships with falsy ids

### DIFF
--- a/lib/JSONAPISerializer.js
+++ b/lib/JSONAPISerializer.js
@@ -364,7 +364,7 @@ module.exports = class JSONAPISerializer {
           } else if (relationship.data === null) {
             // null data
             _.set(deserializedData, relationshipKey, null);
-          } else if (relationship.data.type && relationship.data.id) {
+          } else if (_.has(relationship.data, 'type') && _.has(relationship.data, 'id')) {
             // Object data
             _.set(deserializedData, relationshipKey, included
               ? this.deserializeIncluded(relationship.data.type, relationship.data.id, resourceOpts.relationships[relationshipProperty], included)

--- a/test/unit/JSONAPISerializer.test.js
+++ b/test/unit/JSONAPISerializer.test.js
@@ -1139,6 +1139,12 @@ describe('JSONAPISerializer', function() {
             },
             malformedRelationship: {
               data: 'test'
+            },
+            falsyIdRelationship: {
+              data: {
+                type: 'stuff',
+                id: ''
+              }
             }
           }
         }
@@ -1154,6 +1160,7 @@ describe('JSONAPISerializer', function() {
       expect(deserializedData).to.have.property('emptyArray').to.eql([]);
       expect(deserializedData).to.have.property('nullRelationship').to.eql(null);
       expect(deserializedData).to.not.have.property('malformedRelationship');
+      expect(deserializedData).to.have.property('falsyIdRelationship').to.eql('');
       done();
     });
 


### PR DESCRIPTION
A regression was introduced in 1.11.1. This should fix it.