### PR TITLE
Fixes issue with unconvert case and alternative key during deserialize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 coverage/
+.idea/

--- a/lib/JSONAPISerializer.js
+++ b/lib/JSONAPISerializer.js
@@ -487,8 +487,7 @@ module.exports = class JSONAPISerializer {
         let relationshipKey;
         if (resourceOpts.unconvertCase) {
           relationshipKey = this._convertCase(relationshipProperty, resourceOpts.unconvertCase);
-        }
-        else {
+        } else {
           relationshipKey = relationshipProperty;
         }
         if (resourceOpts.relationships[relationshipKey] && resourceOpts.relationships[relationshipKey].alternativeKey) {

--- a/lib/JSONAPISerializer.js
+++ b/lib/JSONAPISerializer.js
@@ -484,7 +484,13 @@ module.exports = class JSONAPISerializer {
         const relationship = data.relationships[relationshipProperty];
 
         // Support alternativeKey options for relationships
-        let relationshipKey = relationshipProperty;
+        let relationshipKey;
+        if (resourceOpts.unconvertCase) {
+          relationshipKey = this._convertCase(relationshipProperty, resourceOpts.unconvertCase);
+        }
+        else {
+          relationshipKey = relationshipProperty;
+        }
         if (resourceOpts.relationships[relationshipKey] && resourceOpts.relationships[relationshipKey].alternativeKey) {
           relationshipKey = resourceOpts.relationships[relationshipKey].alternativeKey;
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-api-serializer",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "Framework agnostic JSON API serializer.",
   "main": "index.js",
   "scripts": {

--- a/test/unit/JSONAPISerializer.test.js
+++ b/test/unit/JSONAPISerializer.test.js
@@ -1586,6 +1586,42 @@ describe('JSONAPISerializer', function() {
       expect(deserializedData).to.have.property('article_author');
       done();
     });
+    
+    it('should deserialize with \'unconvertCase\' options with \'alternative_key\' relationship', function(done) {
+      const Serializer = new JSONAPISerializer();
+      Serializer.register('articles', {
+        unconvertCase: 'snake_case',
+        relationships: {
+          article_author: {
+            alternativeKey: 'article_author_id',
+            type: 'authors',
+          },
+        }
+      });
+    
+      const data = {
+        data: {
+          type: 'article',
+          id: '1',
+          attributes: {
+            createdAt: '2015-05-22T14:56:29.000Z'
+          },
+          relationships: {
+            articleAuthor: {
+              data: {
+                type: 'people',
+                id: '1'
+              }
+            }
+          }
+        }
+      };
+    
+      const deserializedData = Serializer.deserialize('articles', data);
+      expect(deserializedData).to.have.property('created_at');
+      expect(deserializedData).to.have.property('article_author_id');
+      done();
+    });
 
     it('should deserialize all attributes of data except for blacklisted attributes', function(done) {
       const data = {


### PR DESCRIPTION
Fixes issue involving a targeted unconvert case and an alternative key wherein the alternative key could be reached due to a match for the unconverted case not existing.

This issue arose when the data to be deserialized was in a particular case (specified by the convert case), but it would not properly use the alternative key due to the relation key having not been unconverted yet. 

Example:
```
      Serializer.register('articles', {
        unconvertCase: 'snake_case',
        relationships: {
          article_author: {
            alternativeKey: 'article_author_id',
            type: 'authors',
          },
        }
      });
```

```
      const data = {
        data: {
          type: 'article',
          id: '1',
          attributes: {
            createdAt: '2015-05-22T14:56:29.000Z'
          },
          relationships: {
            articleAuthor: {
              data: {
                type: 'people',
                id: '1'
              }
            }
          }
        }
      };
```

"articleAuthor" does not get deserialized to "article_author_id" in this particular case without these changes.
