### PR TITLE
Add excludeData flag to serialize and serializeAsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,23 @@ The output data will be :
 }
 ```
 
+There is an available argument `excludeData` that will exclude the `data`
+property from the serialized object. This can be used in cases where you may
+want to only include the `topLevelMeta` in your response, such as a `DELETE`
+response with only a `meta` property, or other cases defined in the
+JSON:API spec.
+
+```javascript
+// Synchronously (blocking)
+const result = Serializer.serialize('article', data, 'default', {count: 2}, true);
+
+// Asynchronously (non-blocking)
+Serializer.serializeAsync('article', data, 'default', {count: 2}, true)
+  .then((result) => {
+    ...
+  });
+```
+
 Some others examples are available in [tests folders](https://github.com/danivek/json-api-serializer/blob/master/test/)
 
 ### Deserialize

--- a/lib/JSONAPISerializer.js
+++ b/lib/JSONAPISerializer.js
@@ -73,7 +73,7 @@ module.exports = class JSONAPISerializer {
    * @param {object|object[]} data input data.
    * @param {string|object} [schema='default'] resource's schema name.
    * @param {object} [extraData] additional data that can be used in topLevelMeta options.
-   * @param {boolean} excludeData boolean that can be set to exclude the `data` property in serialized data.
+   * @param {boolean} [excludeData] boolean that can be set to exclude the `data` property in serialized data.
    * @returns {object} serialized data.
    */
   serialize(type, data, schema, extraData, excludeData) {
@@ -137,7 +137,7 @@ module.exports = class JSONAPISerializer {
    * @param {object|object[]} data input data.
    * @param {string} [schema='default'] resource's schema name.
    * @param {object} [extraData] additional data that can be used in topLevelMeta options.
-   * @param {boolean} excludeData boolean that can be set to exclude the `data` property in serialized data.
+   * @param {boolean} [excludeData] boolean that can be set to exclude the `data` property in serialized data.
    * @returns {Promise} resolves with serialized data.
    */
   serializeAsync(type, data, schema, extraData, excludeData) {

--- a/lib/JSONAPISerializer.js
+++ b/lib/JSONAPISerializer.js
@@ -73,9 +73,10 @@ module.exports = class JSONAPISerializer {
    * @param {object|object[]} data input data.
    * @param {string|object} [schema='default'] resource's schema name.
    * @param {object} [extraData] additional data that can be used in topLevelMeta options.
+   * @param {boolean} excludeData boolean that can be set to exclude the `data` property in serialized data.
    * @returns {object} serialized data.
    */
-  serialize(type, data, schema, extraData) {
+  serialize(type, data, schema, extraData, excludeData) {
     // Support optional arguments (schema)
     if (arguments.length === 3) {
       if (typeof schema === 'object') {
@@ -107,13 +108,21 @@ module.exports = class JSONAPISerializer {
       options = this.schemas[type][schema];
     }
 
+    let dataProperty;
+
+    if (excludeData) {
+      dataProperty = undefined;
+    } else if (isDynamicType) {
+      dataProperty = this.serializeMixedResource(options, data, included, extraData);
+    } else {
+      dataProperty = this.serializeResource(type, data, options, included, extraData);
+    }
+
     return {
       jsonapi: options.jsonapiObject ? { version: '1.0' } : undefined,
       meta: this.processOptionsValues(data, extraData, options.topLevelMeta, 'extraData'),
       links: this.processOptionsValues(data, extraData, options.topLevelLinks, 'extraData'),
-      data: isDynamicType
-        ? this.serializeMixedResource(options, data, included, extraData)
-        : this.serializeResource(type, data, options, included, extraData),
+      data: dataProperty,
       included: included.size ? [...included.values()] : undefined
     };
   }
@@ -128,9 +137,10 @@ module.exports = class JSONAPISerializer {
    * @param {object|object[]} data input data.
    * @param {string} [schema='default'] resource's schema name.
    * @param {object} [extraData] additional data that can be used in topLevelMeta options.
+   * @param {boolean} excludeData boolean that can be set to exclude the `data` property in serialized data.
    * @returns {Promise} resolves with serialized data.
    */
-  serializeAsync(type, data, schema, extraData) {
+  serializeAsync(type, data, schema, extraData, excludeData) {
     // Support optional arguments (schema)
     if (arguments.length === 3) {
       if (typeof schema === 'object') {
@@ -173,6 +183,9 @@ module.exports = class JSONAPISerializer {
        */
       function next() {
         setImmediate(() => {
+          if (excludeData) {
+            return resolve();
+          }
           if (i >= arrayData.length) {
             return resolve(serializedData);
           }
@@ -197,15 +210,27 @@ module.exports = class JSONAPISerializer {
       }
 
       next();
-    }).then(result => ({
-      jsonapi: options.jsonapiObject ? { version: '1.0' } : undefined,
-      meta: this.processOptionsValues(data, extraData, options.topLevelMeta, 'extraData'),
-      links: this.processOptionsValues(data, extraData, options.topLevelLinks, 'extraData'),
-      // If the source data was an array, we just pass the serialized data array.
-      // Otherwise we try to take the first (and only) item of it or pass null.
-      data: isDataArray ? result : result[0] || null,
-      included: included.size ? [...included.values()] : undefined
-    }));
+    }).then(result => {
+      let dataProperty;
+
+      if (typeof result === 'undefined') {
+        dataProperty = undefined;
+      } else if (isDataArray) {
+        dataProperty = result;
+      } else {
+        dataProperty = result[0] || null;
+      }
+
+      return {
+        jsonapi: options.jsonapiObject ? { version: '1.0' } : undefined,
+        meta: this.processOptionsValues(data, extraData, options.topLevelMeta, 'extraData'),
+        links: this.processOptionsValues(data, extraData, options.topLevelLinks, 'extraData'),
+        // If the source data was an array, we just pass the serialized data array.
+        // Otherwise we try to take the first (and only) item of it or pass null.
+        data: dataProperty,
+        included: included.size ? [...included.values()] : undefined
+      };
+    });
   }
 
   /**


### PR DESCRIPTION
Adds an additional argument to `serialize` and `serializeAsync` to allow excluding the `data` parameter from the output.

See https://github.com/danivek/json-api-serializer/issues/91