### PR TITLE
Added ability to override schema options, added tests, updated docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,23 @@ Serializer.serializeAsync('article', data, 'default', {count: 2}, true)
   });
 ```
 
+#### Override schema options
+
+On each individual call to `serialize` or `serializeAsync`, there is an parameter to override the options of any registered type. For example on a call to serialize, if a whitelist was not defined on the registered schema options, a whitelist (or any other options) for that type can be provided. This parameter is an object, where the key are the registered type names, and the values are the objects to override the registered schema.
+
+In the following example, only the attribute `name` will be serialized on the article, and if there is a relationship for `person`, it will be serialized with `camelCase` even if the registered schema has a different value.
+```
+const result = Serializer.serialize('article', data, 'default', {count: 2}, true), {
+  article: {
+    whitelist: ['name']
+  },
+  person: {
+    convertCase: 'camelCase'
+  }
+};
+```
+
+
 Some others examples are available in [tests folders](https://github.com/danivek/json-api-serializer/blob/master/test/)
 
 ### Deserialize

--- a/lib/JSONAPISerializer.js
+++ b/lib/JSONAPISerializer.js
@@ -74,9 +74,10 @@ module.exports = class JSONAPISerializer {
    * @param {string|object} [schema='default'] resource's schema name.
    * @param {object} [extraData] additional data that can be used in topLevelMeta options.
    * @param {boolean} [excludeData] boolean that can be set to exclude the `data` property in serialized data.
+   * @param {object} [overrideSchemaOptions=] additional schema options, a map of types with options to override
    * @returns {object} serialized data.
    */
-  serialize(type, data, schema, extraData, excludeData) {
+  serialize(type, data, schema, extraData, excludeData, overrideSchemaOptions = {}) {
     // Support optional arguments (schema)
     if (arguments.length === 3) {
       if (typeof schema === 'object') {
@@ -108,14 +109,26 @@ module.exports = class JSONAPISerializer {
       options = this.schemas[type][schema];
     }
 
+    let overrideType = isDynamicType ? type.type : type;
+    if (overrideSchemaOptions[overrideType]) {
+      // Merge default (registered) options and extra options into new options object
+      options = Object.assign({}, options, overrideSchemaOptions[overrideType]);
+    }
+
     let dataProperty;
 
     if (excludeData) {
       dataProperty = undefined;
     } else if (isDynamicType) {
-      dataProperty = this.serializeMixedResource(options, data, included, extraData);
+      dataProperty = this.serializeMixedResource(
+        options,
+        data,
+        included,
+        extraData,
+        overrideSchemaOptions
+      );
     } else {
-      dataProperty = this.serializeResource(type, data, options, included, extraData);
+      dataProperty = this.serializeResource(type, data, options, included, extraData, overrideSchemaOptions);
     }
 
     return {
@@ -138,9 +151,10 @@ module.exports = class JSONAPISerializer {
    * @param {string} [schema='default'] resource's schema name.
    * @param {object} [extraData] additional data that can be used in topLevelMeta options.
    * @param {boolean} [excludeData] boolean that can be set to exclude the `data` property in serialized data.
+   * @param {object} [overrideSchemaOptions=] additional schema options, a map of types with options to override
    * @returns {Promise} resolves with serialized data.
    */
-  serializeAsync(type, data, schema, extraData, excludeData) {
+  serializeAsync(type, data, schema, extraData, excludeData, overrideSchemaOptions = {}) {
     // Support optional arguments (schema)
     if (arguments.length === 3) {
       if (typeof schema === 'object') {
@@ -175,6 +189,12 @@ module.exports = class JSONAPISerializer {
       options = this.schemas[type][schema];
     }
 
+    let overrideType = isDynamicType ? type.type : type
+    if (overrideSchemaOptions[overrideType]) {
+      // Merge default (registered) options and extra options into new options object
+      options = Object.assign({}, options, overrideSchemaOptions[overrideType]);
+    }
+
     return new Promise((resolve, reject) => {
       /**
        * Non-blocking serialization using the immediate queue.
@@ -193,8 +213,14 @@ module.exports = class JSONAPISerializer {
           try {
             // Serialize a single item of the data-array.
             const serializedItem = isDynamicType
-              ? that.serializeMixedResource(type, arrayData[i], included, extraData)
-              : that.serializeResource(type, arrayData[i], options, included, extraData);
+              ? that.serializeMixedResource(
+                  type,
+                  arrayData[i],
+                  included,
+                  extraData,
+                  overrideSchemaOptions
+                )
+              : that.serializeResource(type, arrayData[i], options, included, extraData, overrideSchemaOptions);
 
             if (serializedItem !== null) {
               serializedData.push(serializedItem);
@@ -525,23 +551,24 @@ module.exports = class JSONAPISerializer {
    * @param {object} options resource's configuration options.
    * @param {Map<string, object>} [included] Included resources.
    * @param {object} [extraData] additional data.
+   * @param {object} [overrideSchemaOptions=] additional schema options, a map of types with options to override
    * @returns {object|object[]} serialized data.
    */
-  serializeResource(type, data, options, included, extraData) {
+  serializeResource(type, data, options, included, extraData, overrideSchemaOptions = {}) {
     if (isEmpty(data)) {
       // Return [] or null
       return Array.isArray(data) ? data : null;
     }
 
     if (Array.isArray(data)) {
-      return data.map(d => this.serializeResource(type, d, options, included, extraData));
+      return data.map(d => this.serializeResource(type, d, options, included, extraData, overrideSchemaOptions));
     }
 
     return {
       type,
       id: data[options.id] ? data[options.id].toString() : undefined,
       attributes: this.serializeAttributes(data, options),
-      relationships: this.serializeRelationships(data, options, included, extraData),
+      relationships: this.serializeRelationships(data, options, included, extraData, overrideSchemaOptions),
       meta: this.processOptionsValues(data, extraData, options.meta),
       links: this.processOptionsValues(data, extraData, options.links)
     };
@@ -557,16 +584,17 @@ module.exports = class JSONAPISerializer {
    * @param {object|object[]} data input data.
    * @param {Map<string, object>} [included] Included resources.
    * @param {object} [extraData] additional data.
+   * @param {object} [overrideSchemaOptions=] additional schema options, a map of types with options to override
    * @returns {object|object[]} serialized data.
    */
-  serializeMixedResource(typeOption, data, included, extraData) {
+  serializeMixedResource(typeOption, data, included, extraData, overrideSchemaOptions = {}) {
     if (isEmpty(data)) {
       // Return [] or null
       return Array.isArray(data) ? data : null;
     }
 
     if (Array.isArray(data)) {
-      return data.map(d => this.serializeMixedResource(typeOption, d, included, extraData));
+      return data.map(d => this.serializeMixedResource(typeOption, d, included, extraData, overrideSchemaOptions));
     }
 
     // Resolve type from data (can be a string or a function deriving a type-string from each data-item)
@@ -581,7 +609,13 @@ module.exports = class JSONAPISerializer {
       throw new Error(`No type registered for ${type}`);
     }
 
-    return this.serializeResource(type, data, this.schemas[type].default, included, extraData);
+    let options = this.schemas[type].default;
+    if (overrideSchemaOptions[type]) {
+      // Merge default (registered) options and extra options into new options object
+      options = Object.assign({}, options, overrideSchemaOptions[type]);
+    }
+
+    return this.serializeResource(type, data, options, included, extraData, overrideSchemaOptions);
   }
 
   /**
@@ -633,9 +667,10 @@ module.exports = class JSONAPISerializer {
    * @param {object} options resource's configuration options.
    * @param {Map<string, object>} [included]  Included resources.
    * @param {object} [extraData] additional data.
+   * @param {object} [overrideSchemaOptions=] additional schema options, a map of types with options to override
    * @returns {object} serialized relationships.
    */
-  serializeRelationships(data, options, included, extraData) {
+  serializeRelationships(data, options, included, extraData, overrideSchemaOptions = {}) {
     const serializedRelationships = {};
 
     Object.keys(options.relationships).forEach(relationship => {
@@ -656,7 +691,8 @@ module.exports = class JSONAPISerializer {
           get(data, relationshipKey),
           included,
           data,
-          extraData
+          extraData,
+          overrideSchemaOptions
         )
       };
 
@@ -689,9 +725,10 @@ module.exports = class JSONAPISerializer {
    * @param {Map<string, object>} [included] Included resources.
    * @param {object} [data] the entire resource's data.
    * @param {object} [extraData] additional data.
+   * @param {object} [overrideSchemaOptions=] additional schema options, a map of types with options to override
    * @returns {object|object[]} serialized relationship data.
    */
-  serializeRelationship(rType, rSchema, rData, included, data, extraData) {
+  serializeRelationship(rType, rSchema, rData, included, data, extraData, overrideSchemaOptions = {}) {
     included = included || new Map();
     const schema = rSchema || 'default';
 
@@ -707,7 +744,7 @@ module.exports = class JSONAPISerializer {
 
     if (Array.isArray(rData)) {
       return rData.map(d =>
-        this.serializeRelationship(rType, schema, d, included, data, extraData)
+        this.serializeRelationship(rType, schema, d, included, data, extraData, overrideSchemaOptions)
       );
     }
 
@@ -726,7 +763,13 @@ module.exports = class JSONAPISerializer {
       throw new Error(`No schema "${schema}" registered for type "${type}"`);
     }
 
-    const rOptions = this.schemas[type][schema];
+    let rOptions = this.schemas[type][schema];
+
+    if (overrideSchemaOptions[type]) {
+      // Merge default (registered) options and extra options into new options object
+      rOptions = Object.assign({}, rOptions, overrideSchemaOptions[type]);
+    }
+
     const serializedRelationship = { type };
 
     // Support for unpopulated relationships (an id, or array of ids)
@@ -738,7 +781,7 @@ module.exports = class JSONAPISerializer {
       if (!(Object.keys(rData).length === 1 && rData[rOptions.id])) {
         included.set(
           `${type}-${serializedRelationship.id}`,
-          this.serializeResource(type, rData, rOptions, included, extraData)
+          this.serializeResource(type, rData, rOptions, included, extraData, overrideSchemaOptions)
         );
       }
     }

--- a/lib/JSONAPISerializer.js
+++ b/lib/JSONAPISerializer.js
@@ -109,10 +109,10 @@ module.exports = class JSONAPISerializer {
       options = this.schemas[type][schema];
     }
 
-    let overrideType = isDynamicType ? type.type : type;
+    const overrideType = isDynamicType ? type.type : type;
     if (overrideSchemaOptions[overrideType]) {
       // Merge default (registered) options and extra options into new options object
-      options = Object.assign({}, options, overrideSchemaOptions[overrideType]);
+      options = { ...options, ...overrideSchemaOptions[overrideType] };
     }
 
     let dataProperty;
@@ -128,7 +128,14 @@ module.exports = class JSONAPISerializer {
         overrideSchemaOptions
       );
     } else {
-      dataProperty = this.serializeResource(type, data, options, included, extraData, overrideSchemaOptions);
+      dataProperty = this.serializeResource(
+        type,
+        data,
+        options,
+        included,
+        extraData,
+        overrideSchemaOptions
+      );
     }
 
     return {
@@ -189,10 +196,10 @@ module.exports = class JSONAPISerializer {
       options = this.schemas[type][schema];
     }
 
-    let overrideType = isDynamicType ? type.type : type
+    const overrideType = isDynamicType ? type.type : type;
     if (overrideSchemaOptions[overrideType]) {
       // Merge default (registered) options and extra options into new options object
-      options = Object.assign({}, options, overrideSchemaOptions[overrideType]);
+      options = { ...options, ...overrideSchemaOptions[overrideType] };
     }
 
     return new Promise((resolve, reject) => {
@@ -220,7 +227,14 @@ module.exports = class JSONAPISerializer {
                   extraData,
                   overrideSchemaOptions
                 )
-              : that.serializeResource(type, arrayData[i], options, included, extraData, overrideSchemaOptions);
+              : that.serializeResource(
+                  type,
+                  arrayData[i],
+                  options,
+                  included,
+                  extraData,
+                  overrideSchemaOptions
+                );
 
             if (serializedItem !== null) {
               serializedData.push(serializedItem);
@@ -561,14 +575,22 @@ module.exports = class JSONAPISerializer {
     }
 
     if (Array.isArray(data)) {
-      return data.map(d => this.serializeResource(type, d, options, included, extraData, overrideSchemaOptions));
+      return data.map(d =>
+        this.serializeResource(type, d, options, included, extraData, overrideSchemaOptions)
+      );
     }
 
     return {
       type,
       id: data[options.id] ? data[options.id].toString() : undefined,
       attributes: this.serializeAttributes(data, options),
-      relationships: this.serializeRelationships(data, options, included, extraData, overrideSchemaOptions),
+      relationships: this.serializeRelationships(
+        data,
+        options,
+        included,
+        extraData,
+        overrideSchemaOptions
+      ),
       meta: this.processOptionsValues(data, extraData, options.meta),
       links: this.processOptionsValues(data, extraData, options.links)
     };
@@ -594,7 +616,9 @@ module.exports = class JSONAPISerializer {
     }
 
     if (Array.isArray(data)) {
-      return data.map(d => this.serializeMixedResource(typeOption, d, included, extraData, overrideSchemaOptions));
+      return data.map(d =>
+        this.serializeMixedResource(typeOption, d, included, extraData, overrideSchemaOptions)
+      );
     }
 
     // Resolve type from data (can be a string or a function deriving a type-string from each data-item)
@@ -612,7 +636,7 @@ module.exports = class JSONAPISerializer {
     let options = this.schemas[type].default;
     if (overrideSchemaOptions[type]) {
       // Merge default (registered) options and extra options into new options object
-      options = Object.assign({}, options, overrideSchemaOptions[type]);
+      options = { ...options, ...overrideSchemaOptions[type] };
     }
 
     return this.serializeResource(type, data, options, included, extraData, overrideSchemaOptions);
@@ -728,7 +752,15 @@ module.exports = class JSONAPISerializer {
    * @param {object} [overrideSchemaOptions=] additional schema options, a map of types with options to override
    * @returns {object|object[]} serialized relationship data.
    */
-  serializeRelationship(rType, rSchema, rData, included, data, extraData, overrideSchemaOptions = {}) {
+  serializeRelationship(
+    rType,
+    rSchema,
+    rData,
+    included,
+    data,
+    extraData,
+    overrideSchemaOptions = {}
+  ) {
     included = included || new Map();
     const schema = rSchema || 'default';
 
@@ -744,7 +776,15 @@ module.exports = class JSONAPISerializer {
 
     if (Array.isArray(rData)) {
       return rData.map(d =>
-        this.serializeRelationship(rType, schema, d, included, data, extraData, overrideSchemaOptions)
+        this.serializeRelationship(
+          rType,
+          schema,
+          d,
+          included,
+          data,
+          extraData,
+          overrideSchemaOptions
+        )
       );
     }
 
@@ -767,7 +807,7 @@ module.exports = class JSONAPISerializer {
 
     if (overrideSchemaOptions[type]) {
       // Merge default (registered) options and extra options into new options object
-      rOptions = Object.assign({}, rOptions, overrideSchemaOptions[type]);
+      rOptions = { ...rOptions, ...overrideSchemaOptions[type] };
     }
 
     const serializedRelationship = { type };

--- a/test/unit/JSONAPISerializer.test.js
+++ b/test/unit/JSONAPISerializer.test.js
@@ -1006,6 +1006,86 @@ describe('JSONAPISerializer', function() {
       expect(serializedData).have.property('jsonapi').to.be.undefined;
       done();
     });
+
+    it('should override options with provided override object', function(done) {
+      const Serializer = new JSONAPISerializer();
+      Serializer.register('person', {
+        relationships: {
+          address: {
+            type: 'address'
+          }
+        }
+      });
+      Serializer.register('address', {});
+      Serializer.register('articles', {});
+      const data = {
+        id: '1',
+        'first-name': 'firstName',
+        'last-name': 'lastName',
+        'social-security-number': '000-00-0000',
+        address: {
+          id:'1',
+          'zip-code': 123456,
+          'phone-number': '000-000-0000'
+        }
+      };
+      const serializedData = Serializer.serialize('person', data, 'default', null, null, {
+        'person': {
+          convertCase: 'camelCase',
+          blacklist: ['social-security-number']
+        },
+        'address': {
+          whitelist: ['zip-code']
+        }
+      });
+      expect(serializedData.data.attributes).to.have.property('firstName');
+      expect(serializedData.data.attributes).to.have.property('lastName');
+      expect(serializedData.data.attributes).to.not.have.property('socialSecurityNumber');
+      expect(serializedData.included[0].attributes).to.have.property('zip-code');
+      expect(serializedData.included[0].attributes).to.not.have.property('phone-number');
+      done();
+    });
+
+    it('should override options with provided override object for mixedResourceType', function(done) {
+      const Serializer = new JSONAPISerializer();
+      Serializer.register('person', {
+        convertCase: 'camelCase',
+        relationships: {
+          address: {
+            type: 'address'
+          }
+        }
+      });
+      Serializer.register('address', {});
+      const data = {
+        id: '1',
+        'first-name': 'firstName',
+        'last-name': 'lastName',
+        'social-security-number': '000-00-0000',
+        address: {
+          id:'1',
+          'zip-code': 123456,
+          'phone-number': '000-000-0000'
+        },
+        type: 'person'
+      };
+      const serializedData = Serializer.serialize({
+        type: 'type',
+      }, data, 'default', null, null, {
+        'person': {
+          blacklist: ['social-security-number']
+        },
+        'address': {
+          whitelist: ['zip-code']
+        }
+      });
+      expect(serializedData.data.attributes).to.have.property('firstName');
+      expect(serializedData.data.attributes).to.have.property('lastName');
+      expect(serializedData.data.attributes).to.not.have.property('socialSecurityNumber');
+      expect(serializedData.included[0].attributes).to.have.property('zip-code');
+      expect(serializedData.included[0].attributes).to.not.have.property('phone-number');
+      done();
+    });
   });
 
   describe('serializeAsync', function() {
@@ -1167,6 +1247,46 @@ describe('JSONAPISerializer', function() {
           expect(serializedData.data.attributes).to.have.property('title');
           expect(serializedData.data.attributes).to.have.property('body');
           expect(serializedData.included).to.be.undefined;
+        });
+    });
+
+    it('should override options with provided override object', function(done) {
+      const Serializer = new JSONAPISerializer();
+      Serializer.register('person', {
+        relationships: {
+          address: {
+            type: 'address'
+          }
+        }
+      });
+      Serializer.register('address', {});
+      const data = {
+        id: '1',
+        'first-name': 'firstName',
+        'last-name': 'lastName',
+        'social-security-number': '000-00-0000',
+        address: {
+          id:'1',
+          'zip-code': 123456,
+          'phone-number': '000-000-0000'
+        }
+      };
+      Serializer.serializeAsync('person', data, 'default', null, null, {
+        'person': {
+          convertCase: 'camelCase',
+          blacklist: ['social-security-number']
+        },
+        'address': {
+          whitelist: ['zip-code']
+        }
+      })
+        .then(serializedData => {
+          expect(serializedData.data.attributes).to.have.property('firstName');
+          expect(serializedData.data.attributes).to.have.property('lastName');
+          expect(serializedData.data.attributes).to.not.have.property('socialSecurityNumber');
+          expect(serializedData.included[0].attributes).to.have.property('zip-code');
+          expect(serializedData.included[0].attributes).to.not.have.property('phone-number');
+          done();
         });
     });
   });


### PR DESCRIPTION
This allows the user to override a schema on a particular serialize call.

The use case I had for this was that on every request, each user might have their own permissions on what columns they are allowed to retrieve. This provides the ability to configure white list and black lists for attributes per call.