### PR TITLE
feat: improve error serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ Using an instance of `Error`:
 const error = new Error('An error occurred');
 error.id = 123
 error.links = { about: 'https://example.com/errors/123' }
-error.status = 500;
+error.status = 500; // or `statusCode`
 error.code = 'xyz'
 error.meta = { time: Date.now() }
 
@@ -475,7 +475,7 @@ class MyCustomError extends Error {
     this.links = {
       about: 'https://example.com/errors/123'
     }
-    this.status = 500
+    this.status = 500 // or `statusCode`
     this.code = 'xyz'
     this.meta = {
       time: Date.now()
@@ -516,7 +516,7 @@ Serializer.serializeError({
   links: {
     about: 'https://example.com/errors/123'
   },
-  status: 500,
+  status: 500, // or `statusCode`
   code: 'xyz',
   title: 'UserNotFound',
   detail: 'Unable to find a user with the provided ID',
@@ -536,7 +536,7 @@ The result will be:
       "links": {
         "about": "https://example.com/errors/123"
       },
-      "status": "404",
+      "status": "500",
       "code": "xyz",
       "title": "UserNotFound",
       "detail": "Unable to find a user with the provided ID",

--- a/lib/JSONAPISerializer.js
+++ b/lib/JSONAPISerializer.js
@@ -383,51 +383,19 @@ module.exports = class JSONAPISerializer {
   /**
    * Serialize any error into a JSON API error document.
    * Input data can be:
-   *  - An Error or an array of Error.
-   *  - A JSON API error object or an array of JSON API error object.
+   *  - An `Error` or an array of `Error` instances.
+   *  - A JSON API error object or an array of JSON API error objects.
    *
    * @see {@link http://jsonapi.org/format/#errors}
    * @function JSONAPISerializer#serializeError
    * @param {Error|Error[]|object|object[]} error an Error, an array of Error, a JSON API error object, an array of JSON API error object.
-   * @returns {Promise} resolves with serialized error.
+   * @returns {object} resolves with serialized error.
    */
   serializeError(error) {
-    /**
-     * An Error object enhanced with status or/and custom code properties.
-     *
-     * @typedef {Error} ErrorWithStatus
-     * @property {string} [status] status code error
-     * @property {string} [code] code error
-     */
-
-    /**
-     * @private
-     * @param {Error|ErrorWithStatus|object} err an Error, a JSON API error object or an ErrorWithStatus.
-     * @returns {object} valid JSON API error.
-     */
-    function convertToError(err) {
-      let serializedError;
-
-      if (err instanceof Error) {
-        const status = err.status || err.statusCode;
-
-        serializedError = {
-          status: status && status.toString(),
-          code: err.code,
-          title: err.title || err.constructor.name,
-          detail: err.message,
-        };
-      } else {
-        serializedError = validateError(err);
-      }
-
-      return serializedError;
-    }
-
     return {
       errors: Array.isArray(error)
-        ? error.map((err) => convertToError(err))
-        : [convertToError(error)],
+        ? error.map((err) => validateError(err))
+        : [validateError(error)]
     };
   }
 

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -144,10 +144,11 @@ function validateDynamicTypeOptions(options) {
 }
 
 /**
- * Validate a JSONAPI error object
+ * Validate a JSON:API error object
  *
  * @function validateError
  * @private
+ * @throws Will throw an error if the argument is not an object
  * @param {object} err a JSONAPI error object
  * @returns {object} JSONAPI  valid error object
  */
@@ -156,8 +157,25 @@ function validateError(err) {
     throw new Error('error must be an object');
   }
 
-  const { id, links, status, code, title, detail, source, meta } = err;
+  const { id, links, status, statusCode, code, title, detail, source, meta } = err;
 
+  /**
+   * Validates the `links` property, ensuring that it is an object and,
+   * if present, contains valid members. From the JSON:API spec:
+   *
+   * links: a links object containing the following members:
+   *   about: a link that leads to further details about this particular
+   *          occurrence of the problem.
+   *
+   * @function isValidLink
+   * @private
+   * @see https://jsonapi.org/format/#error-objects
+   * @throws Will throw an error if the argument is not an object
+   * @throws Will throw an error if the argument contains unpermitted members
+   * @throws Will throw an error if `links.about` is present but not a string
+   * @param {object} linksObj
+   * @returns {object}
+   */
   const isValidLink = function isValidLink(linksObj) {
     const permittedMembers = ['about'];
 
@@ -178,6 +196,28 @@ function validateError(err) {
     return links;
   };
 
+  /**
+   * Validates the `source` property, ensuring that it is an object and,
+   * if present, contains valid members. From the JSON:API spec:
+   *
+   * source: an object containing references to the source of the error,
+   *         optionally including any of the following members:
+   *   pointer: a JSON Pointer [RFC6901] to the associated entity in the
+   *            request document [e.g. "/data" for a primary data object,
+   *            or "/data/attributes/title" for a specific attribute].
+   *   parameter: a string indicating which URI query parameter caused the
+   *              error.
+   *
+   * @function isValidSource
+   * @private
+   * @see https://jsonapi.org/format/#error-objects
+   * @param {object} sourceObj
+   * @throws Will throw an error if the argument is not an object
+   * @throws Will throw an error if the argument contains unpermitted members
+   * @throws Will throw an error if `sourceObj.pointer` is present but not a string
+   * @throws Will throw an error if `sourceObj.parameter` is present but not a string
+   * @returns {object}
+   */
   const isValidSource = function isValidSource(sourceObj) {
     const permittedMembers = ['pointer', 'parameter'];
 
@@ -202,6 +242,20 @@ function validateError(err) {
     return source;
   };
 
+  /**
+   * Validates the `meta` property, ensuring that it is an object. From
+   * the JSON:API spec:
+   *
+   * meta: a meta object containing non-standard meta-information about
+   *       the error.
+   *
+   * @function isValidMeta
+   * @private
+   * @see https://jsonapi.org/format/#error-objects
+   * @param {object} metaObj
+   * @throws Will throw an error if the argument is not an object
+   * @returns {object}
+   */
   const isValidMeta = function isValidMeta(metaObj) {
     if (typeof metaObj !== 'object') {
       throw new Error("error 'meta' property must be an object");
@@ -213,10 +267,13 @@ function validateError(err) {
   /**
    * Determines if the provided number is a valid HTTP status code.
    *
-   * @param {number} statusCode The status code to validate
+   * @function isValidHttpStatusCode
+   * @private
+   * @see https://jsonapi.org/format/#error-objects
+   * @param {number} theStatusCode The status code to validate
    * @returns {boolean}
    */
-  const isValidHttpStatusCode = function isValidHttpStatusCode(statusCode) {
+  const isValidHttpStatusCode = function isValidHttpStatusCode(theStatusCode) {
     const validHttpStatusCodes = [
       // 1XX: Informational
       100,101, 102, // eslint-disable-line
@@ -236,11 +293,27 @@ function validateError(err) {
       500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511, 599 // eslint-disable-line
     ];
 
-    return validHttpStatusCodes.includes(statusCode);
+    return validHttpStatusCodes.includes(theStatusCode);
   };
 
-  const isValidStatus = function isValidStatus(statusCode) {
-    const statusAsNumber = Number(statusCode);
+  /**
+   * Validates a status code, ensuring that it is both a number and a valid
+   * HTTP status code. From the JSON:API spec:
+   *
+   * status: the HTTP status code applicable to this problem, expressed
+   *         as a string value.
+   *
+   * @function isValidStatus
+   * @private
+   * @see https://jsonapi.org/format/#error-objects
+   * @param {string|number} theStatusCode
+   * @throws Will throw an error if the argument is not number-like
+   * @throws Will throw an error if the argument is not a valid HTTP status code
+   * @returns {string}
+   */
+  const isValidStatus = function isValidStatus(theStatusCode) {
+    const statusAsNumber = Number(theStatusCode);
+
     if (Number.isNaN(statusAsNumber)) {
       throw new Error("error 'status' must be a number");
     }
@@ -249,15 +322,19 @@ function validateError(err) {
       throw new Error("error 'status' must be a valid HTTP status code");
     }
 
-    return status.toString();
+    return statusAsNumber.toString();
   };
 
   const error = {};
   if (id) error.id = id;
   if (links && Object.keys(links).length) error.links = isValidLink(links);
-  if (status) error.status = isValidStatus(status);
+  if (status || statusCode) error.status = isValidStatus(status || statusCode);
   if (code) error.code = code.toString();
-  error.title = title ? title.toString() : err.constructor.name;
+  if (title) {
+    error.title = title.toString();
+  } else if (err.constructor.name !== 'Object') {
+    error.title = err.constructor.name;
+  }
   error.detail = detail ? detail.toString() : err.message;
   if (source && Object.keys(source).length) error.source = isValidSource(source);
   if (meta && Object.keys(meta).length) error.meta = isValidMeta(meta);

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -159,33 +159,37 @@ function validateError(err) {
   const { id, links, status, code, title, detail, source, meta } = err;
 
   const isValidLink = function isValidLink(linksObj) {
+    const permittedMembers = ['about'];
+
     if (typeof linksObj !== 'object') {
       throw new Error("error 'link' property must be an object");
     }
 
     Object.keys(linksObj).forEach((key) => {
-      if (typeof linksObj[key] !== 'object' && typeof linksObj[key] !== 'string') {
-        throw new Error(`error 'links.${key}' must be a string or an object`);
-      }
-
-      if (typeof linksObj[key] === 'object') {
-        if (linksObj[key].href && typeof linksObj[key].href !== 'string') {
-          throw new Error(`'links.${key}.href' property must be a string`);
-        }
-
-        if (linksObj[key].meta && typeof linksObj[key].meta !== 'object') {
-          throw new Error(`'links.${key}.meta' property must be an object`);
-        }
+      if (!permittedMembers.includes(key)) {
+        throw new Error(`error 'links.${key}' is not permitted`);
       }
     });
+
+    if (linksObj.about && typeof linksObj.about !== 'string') {
+      throw new Error("'links.about' property must be a string");
+    }
 
     return links;
   };
 
   const isValidSource = function isValidSource(sourceObj) {
+    const permittedMembers = ['pointer', 'parameter'];
+
     if (typeof sourceObj !== 'object') {
       throw new Error("error 'source' property must be an object");
     }
+
+    Object.keys(sourceObj).forEach((key) => {
+      if (!permittedMembers.includes(key)) {
+        throw new Error(`error 'source.${key}' is not permitted`);
+      }
+    });
 
     if (sourceObj.pointer && typeof sourceObj.pointer !== 'string') {
       throw new Error("error 'source.pointer' property must be a string");
@@ -198,15 +202,65 @@ function validateError(err) {
     return source;
   };
 
+  const isValidMeta = function isValidMeta(metaObj) {
+    if (typeof metaObj !== 'object') {
+      throw new Error("error 'meta' property must be an object");
+    }
+
+    return meta;
+  };
+
+  /**
+   * Determines if the provided number is a valid HTTP status code.
+   *
+   * @param {number} statusCode The status code to validate
+   * @returns {boolean}
+   */
+  const isValidHttpStatusCode = function isValidHttpStatusCode(statusCode) {
+    const validHttpStatusCodes = [
+      // 1XX: Informational
+      100,101, 102, // eslint-disable-line
+
+      // 2XX: Success
+      200, 201, 202, 203, 204, 205, 206, 207, 208, 226, // eslint-disable-line
+
+      // 3XX: Redirection
+      300, 301, 302, 303, 304, 305, 307, 308, // eslint-disable-line
+
+      // 4XX: Client Error
+      400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, // eslint-disable-line
+      413, 414, 415, 416, 417, 418, 421, 422, 423, 424, 426, 428, 429, // eslint-disable-line
+      431, 444, 451, 499, // eslint-disable-line
+
+      // 5XX: Server Error
+      500, 501, 502, 503, 504, 505, 506, 507, 508, 510, 511, 599 // eslint-disable-line
+    ];
+
+    return validHttpStatusCodes.includes(statusCode);
+  };
+
+  const isValidStatus = function isValidStatus(statusCode) {
+    const statusAsNumber = Number(statusCode);
+    if (Number.isNaN(statusAsNumber)) {
+      throw new Error("error 'status' must be a number");
+    }
+
+    if (!isValidHttpStatusCode(statusAsNumber)) {
+      throw new Error("error 'status' must be a valid HTTP status code");
+    }
+
+    return status.toString();
+  };
+
   const error = {};
-  if (id) error.id = id.toString();
-  if (links) error.links = isValidLink(links);
-  if (status) error.status = status.toString();
+  if (id) error.id = id;
+  if (links && Object.keys(links).length) error.links = isValidLink(links);
+  if (status) error.status = isValidStatus(status);
   if (code) error.code = code.toString();
-  if (title) error.title = title.toString();
-  if (detail) error.detail = detail.toString();
-  if (source) error.source = isValidSource(source);
-  if (meta) error.meta = meta;
+  error.title = title ? title.toString() : err.constructor.name;
+  error.detail = detail ? detail.toString() : err.message;
+  if (source && Object.keys(source).length) error.source = isValidSource(source);
+  if (meta && Object.keys(meta).length) error.meta = isValidMeta(meta);
 
   return error;
 }


### PR DESCRIPTION
Improves the serialization of errors to be compliant with the JSON:API
spec:

* Remove explicit check for `Error` instances and, instead, validate
  both instances of `Error` and POJOs using `validateError`
* Restrict `links` object properties to `about`
* Restrict `links.about` object property type to string
* Restrict `source` object properties to `pointer` and `parameter`
* Restrict `meta` object property type to object
* Add function for validating `status` against a list of known HTTP
  status codes
* Restrict `status` object property type to number
* Add tests for new functionality
* Update tests for changed functionality
* Update `README.md` with additional usage examples

Addresses issue #110 