### PR TITLE
Deserialize unregisterered relationships

### DIFF
--- a/lib/JSONAPISerializer.js
+++ b/lib/JSONAPISerializer.js
@@ -92,29 +92,7 @@ module.exports = class JSONAPISerializer {
 
     const included = new Map();
     const isDynamicType = typeof type === 'object';
-    let options;
-
-    if (isDynamicType) {
-      // Dynamic type option
-      options = validateDynamicTypeOptions(type);
-    } else {
-      // Serialize data with the defined type
-      if (!this.schemas[type]) {
-        throw new Error(`No type registered for ${type}`);
-      }
-
-      if (schema && !this.schemas[type][schema]) {
-        throw new Error(`No schema ${schema} registered for ${type}`);
-      }
-
-      options = this.schemas[type][schema];
-    }
-
-    const overrideType = isDynamicType ? type.type : type;
-    if (overrideSchemaOptions[overrideType]) {
-      // Merge default (registered) options and extra options into new options object
-      options = { ...options, ...overrideSchemaOptions[overrideType] };
-    }
+    const options = this._getSchemaOptions(type, schema, overrideSchemaOptions);
 
     let dataProperty;
 
@@ -181,27 +159,7 @@ module.exports = class JSONAPISerializer {
     const serializedData = [];
     const that = this;
     let i = 0;
-    let options;
-
-    if (isDynamicType) {
-      options = validateDynamicTypeOptions(type);
-    } else {
-      if (!this.schemas[type]) {
-        throw new Error(`No type registered for ${type}`);
-      }
-
-      if (schema && !this.schemas[type][schema]) {
-        throw new Error(`No schema ${schema} registered for ${type}`);
-      }
-
-      options = this.schemas[type][schema];
-    }
-
-    const overrideType = isDynamicType ? type.type : type;
-    if (overrideSchemaOptions[overrideType]) {
-      // Merge default (registered) options and extra options into new options object
-      options = { ...options, ...overrideSchemaOptions[overrideType] };
-    }
+    const options = this._getSchemaOptions(type, schema, overrideSchemaOptions);
 
     return new Promise((resolve, reject) => {
       /**
@@ -443,12 +401,14 @@ module.exports = class JSONAPISerializer {
     if (data.relationships) {
       Object.keys(data.relationships).forEach((relationshipProperty) => {
         const relationship = data.relationships[relationshipProperty];
+        const relationshipType = this._getRelationshipDataType(relationship.data);
 
         const relationshipKey = options.unconvertCase
           ? this._convertCase(relationshipProperty, options.unconvertCase)
           : relationshipProperty;
 
-        const relationshipOptions = options.relationships[relationshipKey];
+        const relationshipOptions =
+          options.relationships[relationshipKey] || this.schemas[relationshipType];
 
         const deserializeFunction = (relationshipData) => {
           if (relationshipOptions && relationshipOptions.deserialize) {
@@ -656,11 +616,7 @@ module.exports = class JSONAPISerializer {
       throw new Error(`No type registered for ${type}`);
     }
 
-    let options = this.schemas[type].default;
-    if (overrideSchemaOptions[type]) {
-      // Merge default (registered) options and extra options into new options object
-      options = { ...options, ...overrideSchemaOptions[type] };
-    }
+    const options = this._getSchemaOptions(type, 'default', overrideSchemaOptions);
 
     return this.serializeResource(type, data, options, included, extraData, overrideSchemaOptions);
   }
@@ -913,6 +869,48 @@ module.exports = class JSONAPISerializer {
     }
 
     return processedOptions && Object.keys(processedOptions).length ? processedOptions : undefined;
+  }
+
+  /**
+   * Get the schema options for the given type and optional schema.
+   *
+   * @function JSONAPISerializer#_getSchemaOptions
+   * @private
+   * @param {string|object} [type] the type to get schema options for.
+   * @param {schema} [schema] the schema name to get options for.
+   * @param {object} [overrideSchemaOptions] optional options to override schema options.
+   * @returns {object} the schema options for the given type.
+   */
+  _getSchemaOptions(type, schema, overrideSchemaOptions = {}) {
+    const isDynamicType = typeof type === 'object';
+    const overrideType = isDynamicType ? type.type : type;
+    const overrideOptions = { ...(overrideSchemaOptions[overrideType] || {}) };
+
+    if (isDynamicType) {
+      return validateDynamicTypeOptions(type);
+    }
+
+    if (!this.schemas[type]) {
+      throw new Error(`No type registered for ${type}`);
+    }
+
+    if (schema && !this.schemas[type][schema]) {
+      throw new Error(`No schema ${schema} registered for ${type}`);
+    }
+
+    return { ...this.schemas[type][schema], ...overrideOptions };
+  }
+
+  _getRelationshipDataType(data) {
+    if (data === null || typeof data === 'undefined') {
+      return null;
+    }
+
+    if (Array.isArray(data)) {
+      return get(data[0], 'type');
+    }
+
+    return data.type;
   }
 
   /**

--- a/test/unit/JSONAPISerializer.test.js
+++ b/test/unit/JSONAPISerializer.test.js
@@ -671,6 +671,126 @@ describe('JSONAPISerializer', function() {
     });
   });
 
+  describe('deserializeRelationships', () => {
+    it('should deserialize relationships when unregistered relationship is null', () => {
+      const Serializer = new JSONAPISerializer();
+      Serializer.register('article');
+      Serializer.register('people');
+
+      const data = {
+        data: {
+          id: '1',
+          type: 'article',
+          relationships: {
+            author: {}
+          }
+        },
+        included: [
+          {
+            type: 'people',
+            id: '1'
+          }
+        ]
+      };
+
+      const deserialized = Serializer.deserialize('article', data);
+
+      expect(deserialized.author).to.eql(undefined);
+    });
+
+    it('should deserialize relationships when unregistered relationship is empty', () => {
+      const Serializer = new JSONAPISerializer();
+      Serializer.register('article');
+      Serializer.register('people');
+
+      const data = {
+        data: {
+          id: '1',
+          type: 'article',
+          relationships: {
+            authors: {
+              data: []
+            }
+          }
+        },
+        included: [
+          {
+            type: 'people',
+            id: '1'
+          }
+        ]
+      };
+
+      const deserialized = Serializer.deserialize('article', data);
+
+      expect(deserialized.authors).to.be.empty;
+    });
+
+    it('should deserialize relationships when unregistered relationship is an array', () => {
+      const Serializer = new JSONAPISerializer();
+      Serializer.register('article');
+      Serializer.register('people');
+
+      const data = {
+        data: {
+          id: '1',
+          type: 'article',
+          relationships: {
+            authors: {
+              data: [
+                {
+                  type: 'people',
+                  id: '1'
+                }
+              ]
+            }
+          }
+        },
+        included: [
+          {
+            type: 'people',
+            id: '1'
+          }
+        ]
+      };
+
+      const deserialized = Serializer.deserialize('article', data);
+
+      expect(deserialized.authors[0].id).to.equal('1');
+    });
+
+    it('should deserialize relationships when relationship is not registered', () => {
+      const Serializer = new JSONAPISerializer();
+      Serializer.register('article');
+      Serializer.register('people');
+
+      const data = {
+        data: {
+          id: '1',
+          type: 'article',
+          relationships: {
+            author: {
+              data: {
+                type: 'people',
+                id: '1'
+              }
+            }
+          }
+        },
+        included: [
+          {
+            type: 'people',
+            id: '1'
+          }
+        ]
+      };
+
+      const deserialized = Serializer.deserialize('article', data);
+
+      expect(deserialized.author.id).to.equal('1');
+    });
+  });
+
   describe('serializeAttributes', function() {
     const Serializer = new JSONAPISerializer();
     Serializer.register('articles');


### PR DESCRIPTION
When a resource is deserialized and the included relationship is not
registered an error will be thrown. The error says Cannot read property
'schema' of undefined.

This commit circumvents the error by using the default options for the
given type.

Fixes #129 